### PR TITLE
adapted to lodash _.map

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -129,7 +129,7 @@ S3WriteStream.prototype._part = function _part(buffer, callback) {
  * @see Stream.Writable._writev
  */
 S3WriteStream.prototype._writev = function _writev(buffers, callback) {
-	var chunks = _.pluck(buffers, 'chunk'),
+	var chunks = _.map(buffers, 'chunk'),
 		data = Buffer.concat(chunks, this._writableState.length);
 	return this._part(data, callback);
 };


### PR DESCRIPTION
According to lodash documentation, the `_.pluck` function has been removed and the library now directs developers to the `_.map`, this fixes that.  https://stackoverflow.com/a/35136589/16959